### PR TITLE
Add playbook to install MySQL on Ubuntu

### DIFF
--- a/install_MySQL.yml
+++ b/install_MySQL.yml
@@ -1,0 +1,32 @@
+---
+# Ansible playbook to install and configure MySQL on Ubuntu
+
+# Playbook name
+- name: Install and Configure MySQL
+
+  # Target hosts to apply the playbook to
+  hosts: dbserver
+
+  # Switch to root user to run the tasks
+  become: true
+
+  # Define the tasks to be executed on the dbserver hosts
+  tasks:
+
+    # Update apt cache
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    # Install MySQL Server
+    - name: Install MySQL Server
+      apt:
+        name: mysql-server
+        state: present
+
+    # Start MySQL Service
+    - name: Start MySQL Service
+      service:
+        name: mysql
+        state: started
+        enabled: yes

--- a/inventory
+++ b/inventory
@@ -1,3 +1,6 @@
 10.0.1.248 ansible_python_interpreter=/usr/bin/python3
 10.0.1.95 ansible_python_interpreter=/usr/bin/python3
 10.0.1.11 ansible_python_interpreter=/usr/bin/python3
+
+[dbserver]
+10.0.1.248


### PR DESCRIPTION
Hi,

I have created an Ansible playbook to install and configure MySQL on Ubuntu servers. This playbook automates the installation and configuration process, saving us time and effort.

The playbook performs the following tasks:

    Updates the apt cache
    Installs MySQL server
    Starts the MySQL service

I have tested the playbook on our development server and it ran successfully. Please review the code and let me know if you have any feedback or suggestions for improvement.

Thank you.